### PR TITLE
Allow the use of AWS-CLI environment variables

### DIFF
--- a/aws2fa/core.py
+++ b/aws2fa/core.py
@@ -15,8 +15,12 @@ except NameError:
 class AWS2FA(object):
 
     def __init__(self, **kwargs):
-        self._config_path = os.path.join(self._get_configuration_path(), 'config')
-        self._credentials_path = os.path.join(self._get_configuration_path(), 'credentials')
+        # If environment variables (as used by AWS CLI) are set, prefer them over defaults
+        self._config_path = os.environ.get('AWS_CONFIG_FILE',
+                                           os.path.join(self._get_configuration_path(), 'config'))
+        self._credentials_path = os.environ.get('AWS_SHARED_CREDENTIALS_FILE',
+                                                os.path.join(self._get_configuration_path(), 'credentials'))
+
         self.profile = kwargs.get('profile')
         self.hours = kwargs.get('hours')
         self._profile_credentials = self._get_profile_credentials()


### PR DESCRIPTION
Hi! 

first of all, thank you for creating this tool. It definitely makes our lives easier. 👍 

However, I ran into a use case that caused aws2fa to not cooperate. I have several parts of my system configuration organized by project and/or machine. [This blog post](https://blog.bennycornelissen.nl/post/situation-aware-shell-config/) describes roughly how this works, but the gist of it is that my AWS-CLI configuration files generally don't live at `${HOME}/.aws/`. 

For AWS-CLI that doesn't pose a problem, since you can set environment variables (`AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE`) to work around that. However, aws2fa doesn't use those environment variables. In fact, it doesn't let you override the default location at all. 

I consider myself a Python novice, and also didn't want to change too much of the code base. This PR allows the user to set the aforementioned environment variables, and that's basically it. No new config flags, no changes in default behavior. I've added a test that reads the location of the config file from the environment, and that works locally. 
